### PR TITLE
Update docs to fix some mistakes, add Athena workgroup env var

### DIFF
--- a/content/docs/configuration/environment-variables.md
+++ b/content/docs/configuration/environment-variables.md
@@ -41,7 +41,7 @@ Dekart support started AWS SDK environment variables. Required to query AWS Athe
 
 | Name        | Description           |
 | ------------- | ------------- |
-| `DEKART_ATHENA_CATALOG` <br/><small class="badge badge-info">version &gt;= 0.8</small>     | Amazon S3 query result location required by Athena SDK. This is different from  `DEKART_CLOUD_STORAGE_BUCKET`. First query results are stored in `DEKART_ATHENA_S3_OUTPUT_LOCATION` and then copied to `DEKART_CLOUD_STORAGE_BUCKET`.  <br> *Example*: `athena-results`|
+| `DEKART_ATHENA_CATALOG` <br/><small class="badge badge-info">version &gt;= 0.8</small>     | Data source (group of databases) for AWS Athena to reference when executing queries. Default value is usually `AwsDataCatalog`. <br> *Example*: `my-athena-catalog`|
 | `DEKART_ATHENA_S3_OUTPUT_LOCATION` <br/><small class="badge badge-info">version &gt;= 0.8</small>     | Amazon S3 query result location required by Athena SDK. This is different from  `DEKART_CLOUD_STORAGE_BUCKET`. First query results are stored in `DEKART_ATHENA_S3_OUTPUT_LOCATION` and then copied to `DEKART_CLOUD_STORAGE_BUCKET`.  <br> *Example*: `athena-results`|
 | `DEKART_ATHENA_WORKGROUP` <br/><small class="badge badge-info">version &gt;= 0.12</small>     | AWS Athena workgroup to use when executing Athena queries. If not specified, the default `primary` workgroup will be used. <br> *Example*: `my-athena-workgroup`|
 

--- a/content/docs/configuration/environment-variables.md
+++ b/content/docs/configuration/environment-variables.md
@@ -43,6 +43,7 @@ Dekart support started AWS SDK environment variables. Required to query AWS Athe
 | ------------- | ------------- |
 | `DEKART_ATHENA_CATALOG` <br/><small class="badge badge-info">version &gt;= 0.8</small>     | Amazon S3 query result location required by Athena SDK. This is different from  `DEKART_CLOUD_STORAGE_BUCKET`. First query results are stored in `DEKART_ATHENA_S3_OUTPUT_LOCATION` and then copied to `DEKART_CLOUD_STORAGE_BUCKET`.  <br> *Example*: `athena-results`|
 | `DEKART_ATHENA_S3_OUTPUT_LOCATION` <br/><small class="badge badge-info">version &gt;= 0.8</small>     | Amazon S3 query result location required by Athena SDK. This is different from  `DEKART_CLOUD_STORAGE_BUCKET`. First query results are stored in `DEKART_ATHENA_S3_OUTPUT_LOCATION` and then copied to `DEKART_CLOUD_STORAGE_BUCKET`.  <br> *Example*: `athena-results`|
+| `DEKART_ATHENA_WORKGROUP` <br/><small class="badge badge-info">version &gt;= 0.12</small>     | AWS Athena workgroup to use when executing Athena queries. If not specified, the default `primary` workgroup will be used. <br> *Example*: `my-athena-workgroup`|
 
 ## Google Cloud
 

--- a/content/docs/contributing/build-from-source.md
+++ b/content/docs/contributing/build-from-source.md
@@ -54,7 +54,7 @@ cp .env.example .env
 6. Run Postgres DB locally
 
 ```
-make docker-compose-up
+make up
 ```
 
 7. Run Server

--- a/content/docs/contributing/build-from-source.md
+++ b/content/docs/contributing/build-from-source.md
@@ -60,7 +60,7 @@ make docker-compose-up
 7. Run Server
 
 ```
-make run-dev-server
+make server
 ```
 
 8. Run frontend


### PR DESCRIPTION
### Description

Makes the following changes:
- In the "Build from source" documentations, there are a couple of `make` commands that are out of date, stemming changes to `Makefile` from this commit: https://github.com/dekart-xyz/dekart/commit/579a4ff90f315bfe31945ab4a48cd37f31efc5f7
- Adds the Athena env var `DEKART_ATHENA_WORKGROUP` that's introduced from https://github.com/dekart-xyz/dekart/pull/102
- Fixes the `DEKART_ATHENA_CATALOG` to not have the same description as `DEKART_ATHENA_S3_OUTPUT_LOCATION`

Changing the instructions to these commands works with getting a dev instance of dekart up as of May 9, 2023.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR

Screenshot showing the `make up` command working locally:
![Screen Shot 2023-05-09 at 10 07 19 AM](https://github.com/dekart-xyz/www/assets/5761232/c0d6a799-8b43-4c71-89f2-b81198b3bc1d)

Screenshot showing the `make server` command working locally:
![Screen Shot 2023-05-09 at 10 06 57 AM](https://github.com/dekart-xyz/www/assets/5761232/d3a9ec26-2669-4105-a11f-b17459ce2f7a)
