### PR TITLE
Add setup assistance section and update Docker version to 0.19

### DIFF
--- a/content/docs/configuration/environment-variables.md
+++ b/content/docs/configuration/environment-variables.md
@@ -10,7 +10,17 @@ menu:
 images: []
 ---
 
+## Help with Setup
+
+Need help configuring Dekart? We're here to assist you. Reach out for guidance or troubleshooting!
+
+<a class="btn btn-primary btn" target="_blank" href="https://calendly.com/vladi-dekart/30min" role="button">
+  📅 Book Free Setup Session
+</a>
+
+
 ## Main configuration
+
 
 | Name        | Description           |
 | ------------- | ------------- |

--- a/content/docs/self-hosting/docker.md
+++ b/content/docs/self-hosting/docker.md
@@ -45,7 +45,7 @@ docker run \
   -e DEKART_MAPBOX_TOKEN=${DEKART_MAPBOX_TOKEN} \
   -e DEKART_CORS_ORIGIN=${DEKART_CORS_ORIGIN} \
   -p 8080:8080 \
-  dekartxyz/dekart:0.18
+  dekartxyz/dekart:0.19
 ```
 
 ### Google BigQuery
@@ -66,7 +66,7 @@ docker run \
   -e DEKART_MAPBOX_TOKEN=${DEKART_MAPBOX_TOKEN} \
   -e DEKART_CORS_ORIGIN=${DEKART_CORS_ORIGIN} \
   -p 8080:8080 \
-  dekartxyz/dekart:0.18
+  dekartxyz/dekart:0.19
 ```
 
 ### Snowflake
@@ -90,7 +90,7 @@ docker run -it --rm \
   -e DEKART_MAPBOX_TOKEN=${DEKART_MAPBOX_TOKEN} \
   -e DEKART_CORS_ORIGIN=${DEKART_CORS_ORIGIN} \
   -p 8080:8080 \
-  dekartxyz/dekart:0.18
+  dekartxyz/dekart:0.19
 ```
 
 ### PostgreSQL
@@ -113,7 +113,7 @@ docker run \
   -e DEKART_MAPBOX_TOKEN=${DEKART_MAPBOX_TOKEN} \
   -e DEKART_CORS_ORIGIN=${DEKART_CORS_ORIGIN} \
   -p 8080:8080 \
-  dekartxyz/dekart:0.18
+  dekartxyz/dekart:0.19
 ```
 
 

--- a/content/docs/self-hosting/upgrade.md
+++ b/content/docs/self-hosting/upgrade.md
@@ -12,13 +12,22 @@ menu:
     parent: "self-hosting"
 ---
 
-<p><div class="alert alert-primary" role="alert">
-Before you begin: it is always recommended to back up your Postgres database before upgrading Dekart. On the first run, Dekart applies migrations to the database and you won't be able to downgrade.
-</div></p>
+## Before you begin
 
-For all Docker-based deployments, update the docker tag, for example `dekartxyz/dekart:0.17` -> `dekartxyz/dekart:0.18`
+* Back up your Postgres database before upgrading Dekart. On the first run, Dekart applies migrations to the database and you won't be able to downgrade.
+
+* Do not skip version when upgrading. For example, never go from `0.17 → 0.19`
+
+
 
 ## Migration instructions
+
+Update the docker tag.
+
+**`dekartxyz/dekart:0.18` -> `dekartxyz/dekart:0.19`**
+
+You must now explicitly set both `DEKART_STORAGE` and `DEKART_DATASOURCE`.
+Dekart 0.19 will refuse to start if these two variables are not set.
 
 **`dekartxyz/dekart:0.17` -> `dekartxyz/dekart:0.18`**
 


### PR DESCRIPTION
- Introduced a new section in the environment variables documentation offering help with Dekart setup, including a link to book a free session.
- Updated Docker commands in the self-hosting documentation to reflect the new version `0.19`.
- Revised upgrade instructions to emphasize the importance of backing up the Postgres database and explicitly setting required environment variables.